### PR TITLE
Use go build -i for faster proxy builds

### DIFF
--- a/proxy/compiler.go
+++ b/proxy/compiler.go
@@ -14,8 +14,7 @@ import (
 
 func compile(dest string, src string, vars []string) error {
 	args := []string{
-		"build",
-		"-o", dest,
+		"build", "-i", "-o", dest,
 	}
 
 	if len(vars) > 0 {


### PR DESCRIPTION
This will be redundant in go 1.10, but it seems to speed up larger test suites.