### PR TITLE
Reuse a single server instance

### DIFF
--- a/proxy/client/client_test.go
+++ b/proxy/client/client_test.go
@@ -34,6 +34,7 @@ func TestClient(t *testing.T) {
 
 	c := client.Client{
 		URL:    ts.URL,
+		ID:     "myproxy",
 		Args:   []string{"llamas"},
 		Stdout: stdout,
 		Stderr: stderr,

--- a/proxy/compiler.go
+++ b/proxy/compiler.go
@@ -18,12 +18,13 @@ import (
 )
 
 var (
-	debug string
+	debug  string
 	server string
+	id     string
 )
 
 func main() {
-	c := client.New(server)
+	c := client.New(id, server)
 
 	if debug == "true" {
 		c.Debug = true
@@ -54,6 +55,7 @@ func compile(dest string, src string, vars []string) error {
 
 	t := time.Now()
 
+	debugf("[compiler] go %s %s", strings.Join(args, " "), src)
 	output, err := exec.Command("go", append(args, src)...).CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("Compile of %s failed: %s", src, output)

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -57,8 +57,10 @@ func TestProxyWithStdin(t *testing.T) {
 	outBuf := &bytes.Buffer{}
 
 	cmd := exec.Command(proxy.Path)
+	cmd.Env = []string{}
 	cmd.Stdin = strings.NewReader("This is my stdin\n")
 	cmd.Stdout = outBuf
+	cmd.Stderr = os.Stderr
 	cmd.Start()
 
 	call := <-proxy.Ch


### PR DESCRIPTION
Rather than starting a server per proxy, this re-uses a single server and gives proxies a unique identifier.

```
benchmark                      old ns/op     new ns/op     delta
BenchmarkCreatingProxies-4     632174147     500931806     -20.76%
BenchmarkCallingProxies-4      12569427      11449515      -8.91%

benchmark                     old MB/s     new MB/s     speedup
BenchmarkCallingProxies-4     4.77         5.24         1.10x

benchmark                      old allocs     new allocs     delta
BenchmarkCreatingProxies-4     262            221            -15.65%
BenchmarkCallingProxies-4      342            304            -11.11%

benchmark                      old bytes     new bytes     delta
BenchmarkCreatingProxies-4     86712         38116         -56.04%
BenchmarkCallingProxies-4      132367        95487         -27.86%
```