### PR TITLE
Revert "Use go build -i for faster proxy builds"

### DIFF
--- a/proxy/compiler.go
+++ b/proxy/compiler.go
@@ -36,7 +36,8 @@ func main() {
 
 func compile(dest string, src string, vars []string) error {
 	args := []string{
-		"build", "-i", "-o", dest,
+		"build",
+		"-o", dest,
 	}
 
 	if len(vars) > 0 {


### PR DESCRIPTION
Reverts lox/bintest#2, turns out it actually slowed things down. 