### PR TITLE
Allow using TestMain rather than compiling mocks

### DIFF
--- a/mock.go
+++ b/mock.go
@@ -74,6 +74,26 @@ func NewMock(path string) (*Mock, error) {
 	return m, nil
 }
 
+func NewMockFromTestMain(path string) (*Mock, error) {
+	m := &Mock{}
+
+	proxy, err := proxy.LinkTestBinaryAsProxy(path)
+	if err != nil {
+		return nil, err
+	}
+
+	m.Name = filepath.Base(proxy.Path)
+	m.Path = proxy.Path
+	m.proxy = proxy
+
+	go func() {
+		for call := range m.proxy.Ch {
+			m.invoke(call)
+		}
+	}()
+	return m, nil
+}
+
 func (m *Mock) invoke(call *proxy.Call) {
 	m.Lock()
 	defer m.Unlock()

--- a/proxy/client/client.go
+++ b/proxy/client/client.go
@@ -46,6 +46,14 @@ func New(URL string) *Client {
 	}
 }
 
+func NewFromEnv() *Client {
+	server := os.Getenv(proxy.ServerEnvVar)
+	if server == `` {
+		panic(fmt.Sprintf("No %s environment var set", proxy.ServerEnvVar))
+	}
+	return New(server)
+}
+
 // Run the client, panics on error and returns an exit code on success
 func (c *Client) Run() int {
 	c.debugf("Running %s", strings.Join(c.Args, " "))

--- a/proxy/main_test.go
+++ b/proxy/main_test.go
@@ -1,0 +1,57 @@
+package proxy_test
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/lox/bintest/proxy"
+	"github.com/lox/bintest/proxy/client"
+)
+
+func ExampleLinkTestBinaryAsProxy() {
+	// create a proxy for the git command that echos some debug
+	p, err := proxy.LinkTestBinaryAsProxy("git")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer p.Close()
+
+	// call the proxy like a normal binary in the background
+	cmd := exec.Command(p.Path, "rev-parse")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	// windows needs all the environment variables
+	cmd.Env = os.Environ()
+	cmd.Env = append(cmd.Env, p.Environ()...)
+	cmd.Env = append(cmd.Env, `MY_MESSAGE=Llama party! 🎉`)
+
+	log.Printf("%#v", cmd.Env)
+
+	if err := cmd.Start(); err != nil {
+		log.Fatal(err)
+	}
+
+	// handle invocations of the proxy binary
+	call := <-p.Ch
+	fmt.Fprintln(call.Stdout, call.GetEnv(`MY_MESSAGE`))
+	call.Exit(0)
+
+	// wait for the command to finish
+	cmd.Wait()
+
+	// Output: Llama party! 🎉
+}
+
+func TestMain(m *testing.M) {
+	if filepath.Base(os.Args[0]) != `proxy.test` {
+		os.Exit(client.NewFromEnv().Run())
+	}
+
+	code := m.Run()
+	os.Exit(code)
+}


### PR DESCRIPTION
This allows you to use the TestMain of your test suite as a binary that is linked to mocks vs compiling one. This saves about 500ms per mock created. 