### PR TITLE
Cleanup errcheck warnings

### DIFF
--- a/compiler.go
+++ b/compiler.go
@@ -79,13 +79,17 @@ func compileClient(dest string, vars []string) error {
 		return err
 	}
 
-	defer os.RemoveAll(dir)
-
 	f := filepath.Join(dir, `main.go`)
 	err = ioutil.WriteFile(f, []byte(clientSrc), 0500)
 	if err != nil {
+		_ = os.RemoveAll(dir)
 		return err
 	}
 
-	return compile(dest, f, vars)
+	if err := compile(dest, f, vars); err != nil {
+		_ = os.RemoveAll(dir)
+		return err
+	}
+
+	return os.RemoveAll(dir)
 }

--- a/compiler_test.go
+++ b/compiler_test.go
@@ -15,7 +15,6 @@ func ExampleCompileProxy() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer p.Close()
 
 	// call the proxy like a normal binary in the background
 	cmd := exec.Command(p.Path, "rev-parse")
@@ -26,6 +25,7 @@ func ExampleCompileProxy() {
 	cmd.Env = append(os.Environ(), `MY_MESSAGE=Llama party! 🎉`)
 
 	if err := cmd.Start(); err != nil {
+		_ = p.Close()
 		log.Fatal(err)
 	}
 
@@ -35,7 +35,11 @@ func ExampleCompileProxy() {
 	call.Exit(0)
 
 	// wait for the command to finish
-	cmd.Wait()
+	_ = cmd.Wait()
+
+	if err := p.Close(); err != nil {
+		log.Fatal(err)
+	}
 
 	// Output: Llama party! 🎉
 }

--- a/main_test.go
+++ b/main_test.go
@@ -18,7 +18,6 @@ func ExampleLinkTestBinaryAsProxy() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer p.Close()
 
 	// call the proxy like a normal binary in the background
 	cmd := exec.Command(p.Path, "rev-parse")
@@ -40,7 +39,14 @@ func ExampleLinkTestBinaryAsProxy() {
 	call.Exit(0)
 
 	// wait for the command to finish
-	cmd.Wait()
+	if err := cmd.Wait(); err != nil {
+		log.Fatal(err)
+	}
+
+	// cleanup the proxy
+	if err := p.Close(); err != nil {
+		log.Fatal(err)
+	}
 
 	// Output: Llama party! 🎉
 }

--- a/mock_test.go
+++ b/mock_test.go
@@ -10,8 +10,8 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/fortytw2/leaktest"
 	"github.com/buildkite/bintest"
+	"github.com/fortytw2/leaktest"
 )
 
 type testingT struct {
@@ -44,7 +44,11 @@ func TestCallingMockWithStdErrExpected(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer m.Close()
+	defer func() {
+		if err := m.Close(); err != nil {
+			t.Error(err)
+		}
+	}()
 
 	m.Expect("blargh").AndWriteToStderr("llamas").AndExitWith(0)
 
@@ -71,7 +75,11 @@ func TestCallingMockWithStdOutExpected(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer m.Close()
+	defer func() {
+		if err := m.Close(); err != nil {
+			t.Error(err)
+		}
+	}()
 
 	m.Expect("blargh").AndWriteToStdout("llamas").AndExitWith(0)
 
@@ -99,7 +107,11 @@ func TestCallingMockWithNoExpectationsSet(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer m.Close()
+	defer func() {
+		if err := m.Close(); err != nil {
+			t.Error(err)
+		}
+	}()
 
 	_, err = exec.Command(m.Path, "blargh").CombinedOutput()
 	if err == nil {
@@ -120,7 +132,11 @@ func TestCallingMockWithExpectationsSet(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer m.Close()
+	defer func() {
+		if err := m.Close(); err != nil {
+			t.Error(err)
+		}
+	}()
 
 	m.Expect("blargh").
 		AndWriteToStdout("llamas rock").
@@ -150,7 +166,11 @@ func TestMockWithPassthroughToLocalCommand(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer m.Close()
+	defer func() {
+		if err := m.Close(); err != nil {
+			t.Error(err)
+		}
+	}()
 
 	m.PassthroughToLocalCommand()
 	m.Expect("hello world")
@@ -192,7 +212,11 @@ func TestCallingMockWithExpectationsOfNumberOfCalls(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			defer m.Close()
+			defer func() {
+				if err := m.Close(); err != nil {
+					t.Error(err)
+				}
+			}()
 
 			m.Expect("test").Min(tc.min).Max(tc.max)
 			var failures int
@@ -221,7 +245,11 @@ func TestMockWithCallFunc(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer m.Close()
+	defer func() {
+		if err := m.Close(); err != nil {
+			t.Error(err)
+		}
+	}()
 
 	m.Expect("hello", "world").AndCallFunc(func(c *bintest.Call) {
 		if !reflect.DeepEqual(c.Args[1:], []string{"hello", "world"}) {
@@ -253,7 +281,11 @@ func TestMockRequiresExpectations(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer m.Close()
+	defer func() {
+		if err := m.Close(); err != nil {
+			t.Error(err)
+		}
+	}()
 
 	err = exec.Command(m.Path, "first", "call").Run()
 	if err == nil {
@@ -272,7 +304,11 @@ func TestMockIgnoringUnexpectedInvocations(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer m.Close()
+	defer func() {
+		if err := m.Close(); err != nil {
+			t.Error(err)
+		}
+	}()
 
 	m.IgnoreUnexpectedInvocations()
 	m.Expect("first", "call").Once()
@@ -298,7 +334,11 @@ func TestMockOptionally(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer m.Close()
+	defer func() {
+		if err := m.Close(); err != nil {
+			t.Error(err)
+		}
+	}()
 
 	m.Expect("first", "call").Optionally()
 	m.Expect("third", "call").Once()
@@ -316,7 +356,11 @@ func TestMockMultipleExpects(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer m.Close()
+	defer func() {
+		if err := m.Close(); err != nil {
+			t.Error(err)
+		}
+	}()
 
 	m.Expect("first", "call")
 	m.Expect("first", "call")
@@ -338,7 +382,11 @@ func TestMockExpectWithNoArguments(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer m.Close()
+	defer func() {
+		if err := m.Close(); err != nil {
+			t.Error(err)
+		}
+	}()
 
 	m.Expect().AtLeastOnce()
 
@@ -357,7 +405,11 @@ func TestMockExpectWithMatcherFunc(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer m.Close()
+	defer func() {
+		if err := m.Close(); err != nil {
+			t.Error(err)
+		}
+	}()
 
 	m.Expect().AtLeastOnce().WithMatcherFunc(func(arg ...string) bintest.ArgumentsMatchResult {
 		return bintest.ArgumentsMatchResult{
@@ -382,7 +434,11 @@ func TestMockExpectWithBefore(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer m.Close()
+	defer func() {
+		if err := m.Close(); err != nil {
+			t.Error(err)
+		}
+	}()
 
 	m.PassthroughToLocalCommand().Before(func(i bintest.Invocation) error {
 		if err := bintest.ExpectEnv(t, i.Env, `MY_CUSTOM_ENV=1`, `LLAMAS_ROCK=absolutely`); err != nil {
@@ -422,7 +478,11 @@ func TestMockParallelCommandsWithPassthrough(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer m.Close()
+		defer func() {
+			if err := m.Close(); err != nil {
+				t.Error(err)
+			}
+		}()
 
 		m.Expect(fmt.Sprintf("%d", i)).Exactly(1).AndPassthroughToLocalCommand("sleep")
 

--- a/server.go
+++ b/server.go
@@ -232,16 +232,18 @@ func copyPipeWithFlush(res http.ResponseWriter, pipeReader *io.PipeReader) {
 	for {
 		n, err := pipeReader.Read(buffer)
 		if err != nil {
-			pipeReader.Close()
+			_ = pipeReader.Close()
 			break
 		}
 
 		data := buffer[0:n]
-		res.Write(data)
+		_, _ = res.Write(data)
+
 		if f, ok := res.(http.Flusher); ok {
 			f.Flush()
 		}
-		//reset buffer
+
+		// reset buffer
 		for i := 0; i < n; i++ {
 			buffer[i] = 0
 		}


### PR DESCRIPTION
This cleans up all instances where returned errors weren't being checked (via https://github.com/kisielk/errcheck)