### PR TITLE
Use a compile cache

### DIFF
--- a/compiler.go
+++ b/compiler.go
@@ -1,14 +1,19 @@
 package bintest
 
 import (
-	"crypto/md5"
+	"crypto/sha1"
+	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
+	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
+
+	deadlock "github.com/sasha-s/go-deadlock"
 )
 
 const (
@@ -37,6 +42,11 @@ func main() {
 `
 )
 
+var (
+	compileCacheInstance *compileCache
+	compileLock          deadlock.Mutex
+)
+
 func compile(dest string, src string, vars []string) error {
 	args := []string{
 		"build",
@@ -44,17 +54,20 @@ func compile(dest string, src string, vars []string) error {
 	}
 
 	if len(vars) > 0 || Debug {
+		varsCopy := make([]string, len(vars))
+		copy(varsCopy, vars)
+
 		args = append(args, "-ldflags")
 
-		for idx, val := range vars {
-			vars[idx] = "-X " + val
+		for idx, val := range varsCopy {
+			varsCopy[idx] = "-X " + val
 		}
 
 		if Debug {
-			vars = append(vars, "-X main.debug=true")
+			varsCopy = append(varsCopy, "-X main.debug=true")
 		}
 
-		args = append(args, strings.Join(vars, " "))
+		args = append(args, strings.Join(varsCopy, " "))
 	}
 
 	t := time.Now()
@@ -69,27 +82,168 @@ func compile(dest string, src string, vars []string) error {
 }
 
 func compileClient(dest string, vars []string) error {
+	serverLock.Lock()
+	defer serverLock.Unlock()
+
+	// first off we create a temp dir for caching
+	if compileCacheInstance == nil {
+		var err error
+		compileCacheInstance, err = newCompileCache()
+		if err != nil {
+			return err
+		}
+	}
+
+	// if we can, use the compile cache
+	log.Printf("Checking if cached %v", vars)
+
+	if compileCacheInstance.IsCached(vars) {
+		return compileCacheInstance.Copy(dest, vars)
+	}
+
 	wd, err := os.Getwd()
 	if err != nil {
 		return err
 	}
 
-	dir := fmt.Sprintf(`bintest_stub_%x`, md5.Sum([]byte(dest)))
-	if err = os.Mkdir(filepath.Join(wd, dir), 0700); err != nil {
-		return err
+	// we create a temp subdir relative to current dir so that
+	// we can make use of gopath / vendor dirs
+	dir := fmt.Sprintf(`_bintest_%x`, sha1.Sum([]byte(clientSrc)))
+	f := filepath.Join(dir, `main.go`)
+
+	if _, err := os.Lstat(dir); os.IsNotExist(err) {
+		_ = os.Mkdir(filepath.Join(wd, dir), 0700)
+
+		if err = ioutil.WriteFile(f, []byte(clientSrc), 0500); err != nil {
+			_ = os.RemoveAll(dir)
+			return err
+		}
 	}
 
-	f := filepath.Join(dir, `main.go`)
-	err = ioutil.WriteFile(f, []byte(clientSrc), 0500)
-	if err != nil {
-		_ = os.RemoveAll(dir)
-		return err
-	}
+	log.Printf("Compiling %s for %v", dest, vars)
 
 	if err := compile(dest, f, vars); err != nil {
 		_ = os.RemoveAll(dir)
 		return err
 	}
 
+	// cache for next time
+	if err := compileCacheInstance.Cache(dest, vars); err != nil {
+		return err
+	}
+
 	return os.RemoveAll(dir)
+}
+
+type compileCache struct {
+	Dir string
+}
+
+func newCompileCache() (*compileCache, error) {
+	cc := &compileCache{}
+
+	var err error
+	cc.Dir, err = ioutil.TempDir("", "binproxy")
+	if err != nil {
+		return nil, fmt.Errorf("Error creating temp dir: %v", err)
+	}
+
+	return cc, nil
+}
+
+func (c *compileCache) IsCached(vars []string) bool {
+	path, err := c.file(vars)
+	if err != nil {
+		panic(err)
+	}
+
+	if _, err := os.Stat(path); err == nil {
+		log.Printf("%s exists", path)
+		return true
+	}
+
+	log.Printf("%s doesn't exist", path)
+	return false
+}
+
+func (c *compileCache) Copy(dest string, vars []string) error {
+	src, err := c.file(vars)
+	if err != nil {
+		return err
+	}
+
+	log.Printf("Copying from %s to %s", src, dest)
+	return copyFile(dest, src, 0777)
+}
+
+func (c *compileCache) Cache(src string, vars []string) error {
+	dest, err := c.file(vars)
+	if err != nil {
+		return err
+	}
+
+	log.Printf("Caching %s from %v (into %s)", src, vars, dest)
+	return copyFile(dest, src, 0666)
+}
+
+func (c *compileCache) Key(vars []string) (string, error) {
+	h := sha1.New()
+
+	// add the vars to the hash
+	for _, v := range vars {
+		if _, err := io.WriteString(h, v); err != nil {
+			return "", err
+		}
+	}
+	// factor in client source as well
+	_, _ = io.WriteString(h, clientSrc)
+
+	k := fmt.Sprintf("%x", h.Sum(nil))
+	log.Printf("Hashed %v -> %s", vars, k)
+
+	return k, nil
+}
+
+func (c *compileCache) file(vars []string) (string, error) {
+	if c.Dir == "" {
+		return "", errors.New("No compile cache dir set")
+	}
+
+	k, err := c.Key(vars)
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(c.Dir, k), nil
+}
+
+func copyFile(dst, src string, perm os.FileMode) (err error) {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		err = in.Close()
+	}()
+
+	tmp, err := ioutil.TempFile(filepath.Dir(dst), "")
+	if err != nil {
+		return err
+	}
+	_, err = io.Copy(tmp, in)
+	if err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmp.Name())
+		return err
+	}
+	if err = tmp.Close(); err != nil {
+		_ = os.Remove(tmp.Name())
+		return err
+	}
+	if err = os.Chmod(tmp.Name(), perm); err != nil {
+		_ = os.Remove(tmp.Name())
+		return err
+	}
+
+	return os.Rename(tmp.Name(), dst)
 }

--- a/compiler.go
+++ b/compiler.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -95,8 +94,6 @@ func compileClient(dest string, vars []string) error {
 	}
 
 	// if we can, use the compile cache
-	log.Printf("Checking if cached %v", vars)
-
 	if compileCacheInstance.IsCached(vars) {
 		return compileCacheInstance.Copy(dest, vars)
 	}
@@ -119,8 +116,6 @@ func compileClient(dest string, vars []string) error {
 			return err
 		}
 	}
-
-	log.Printf("Compiling %s for %v", dest, vars)
 
 	if err := compile(dest, f, vars); err != nil {
 		_ = os.RemoveAll(dir)
@@ -158,11 +153,9 @@ func (c *compileCache) IsCached(vars []string) bool {
 	}
 
 	if _, err := os.Stat(path); err == nil {
-		log.Printf("%s exists", path)
 		return true
 	}
 
-	log.Printf("%s doesn't exist", path)
 	return false
 }
 
@@ -171,8 +164,6 @@ func (c *compileCache) Copy(dest string, vars []string) error {
 	if err != nil {
 		return err
 	}
-
-	log.Printf("Copying from %s to %s", src, dest)
 	return copyFile(dest, src, 0777)
 }
 
@@ -181,8 +172,6 @@ func (c *compileCache) Cache(src string, vars []string) error {
 	if err != nil {
 		return err
 	}
-
-	log.Printf("Caching %s from %v (into %s)", src, vars, dest)
 	return copyFile(dest, src, 0666)
 }
 
@@ -198,10 +187,7 @@ func (c *compileCache) Key(vars []string) (string, error) {
 	// factor in client source as well
 	_, _ = io.WriteString(h, clientSrc)
 
-	k := fmt.Sprintf("%x", h.Sum(nil))
-	log.Printf("Hashed %v -> %s", vars, k)
-
-	return k, nil
+	return fmt.Sprintf("%x", h.Sum(nil)), nil
 }
 
 func (c *compileCache) file(vars []string) (string, error) {

--- a/server.go
+++ b/server.go
@@ -2,6 +2,7 @@ package bintest
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"net"
@@ -23,15 +24,25 @@ var (
 	serverLock     deadlock.Mutex
 )
 
+const (
+	defaultPort = 57567
+)
+
 // StartServer starts an instance of a proxy server
 func StartServer() (*Server, error) {
 	serverLock.Lock()
 	defer serverLock.Unlock()
 
 	if serverInstance == nil {
-		l, err := net.Listen("tcp", "127.0.0.1:0")
+		// try a default port first so that we get better cached binary re-usage
+		l, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", defaultPort))
 		if err != nil {
-			return nil, err
+
+			// otherwise grab the first available
+			l, err = net.Listen("tcp", "127.0.0.1:0")
+			if err != nil {
+				return nil, err
+			}
 		}
 
 		s := &Server{


### PR DESCRIPTION
This caches mocks so they only need to be built once per unique server URL. Because this address is generally re-used between tests, this minimises time spent compiling.