### PR TITLE
Proxy.Close() closes Proxy.Ch; avoid goroutine leak

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -172,6 +172,7 @@ func (p *Proxy) newCall(pid int, args []string, env []string, dir string) *Call 
 // Close the proxy and remove the temp directory
 func (p *Proxy) Close() error {
 	p.Server.deregisterProxy(p)
+	close(p.Ch)
 
 	if p.tempDir != "" {
 		if removeErr := os.RemoveAll(p.tempDir); removeErr != nil {


### PR DESCRIPTION
leaktest was picking up lots of leaked goroutines.
This patch introduces `close(p.Ch)` ← `Proxy.Close()` ← `Mock.Close()`.
I guess the main risk is if anything else tries to close the channel (it'll panic) or read/write to the channel. But I think after closing the mock you wouldn't expect that to work.

Before:
<details>
<summary>FAIL	github.com/buildkite/bintest	95.843s</summary>
<pre><code>--- FAIL: TestCallingMockWithStdErrExpected (5.02s)
    leaktest.go:126: leaktest: timed out checking goroutines
    leaktest.go:144: leaktest: leaked goroutine: goroutine 56 [chan receive]:
        github.com/buildkite/bintest.NewMock.func1(0xc0003ea000)
        	/home/pda/bk/bintest/mock.go:69 +0x72
        created by github.com/buildkite/bintest.NewMock
        	/home/pda/bk/bintest/mock.go:68 +0x12a
--- FAIL: TestCallingMockWithStdOutExpected (5.04s)
    leaktest.go:126: leaktest: timed out checking goroutines
    leaktest.go:144: leaktest: leaked goroutine: goroutine 101 [chan receive]:
        github.com/buildkite/bintest.NewMock.func1(0xc0003ea090)
        	/home/pda/bk/bintest/mock.go:69 +0x72
        created by github.com/buildkite/bintest.NewMock
        	/home/pda/bk/bintest/mock.go:68 +0x12a
--- FAIL: TestCallingMockWithNoExpectationsSet (5.03s)
    leaktest.go:126: leaktest: timed out checking goroutines
    leaktest.go:144: leaktest: leaked goroutine: goroutine 91 [chan receive]:
        github.com/buildkite/bintest.NewMock.func1(0xc0000fe000)
        	/home/pda/bk/bintest/mock.go:69 +0x72
        created by github.com/buildkite/bintest.NewMock
        	/home/pda/bk/bintest/mock.go:68 +0x12a
--- FAIL: TestCallingMockWithExpectationsSet (5.01s)
    leaktest.go:126: leaktest: timed out checking goroutines
    leaktest.go:144: leaktest: leaked goroutine: goroutine 178 [chan receive]:
        github.com/buildkite/bintest.NewMock.func1(0xc0000fe090)
        	/home/pda/bk/bintest/mock.go:69 +0x72
        created by github.com/buildkite/bintest.NewMock
        	/home/pda/bk/bintest/mock.go:68 +0x12a
--- FAIL: TestMockWithPassthroughToLocalCommand (5.05s)
    leaktest.go:126: leaktest: timed out checking goroutines
    leaktest.go:144: leaktest: leaked goroutine: goroutine 185 [chan receive]:
        github.com/buildkite/bintest.NewMock.func1(0xc0003ea120)
        	/home/pda/bk/bintest/mock.go:69 +0x72
        created by github.com/buildkite/bintest.NewMock
        	/home/pda/bk/bintest/mock.go:68 +0x12a
--- FAIL: TestCallingMockWithExpectationsOfNumberOfCalls (25.14s)
    --- FAIL: TestCallingMockWithExpectationsOfNumberOfCalls/Zero (5.04s)
        leaktest.go:126: leaktest: timed out checking goroutines
        leaktest.go:144: leaktest: leaked goroutine: goroutine 215 [chan receive]:
            github.com/buildkite/bintest.NewMock.func1(0xc0003ea240)
            	/home/pda/bk/bintest/mock.go:69 +0x72
            created by github.com/buildkite/bintest.NewMock
            	/home/pda/bk/bintest/mock.go:68 +0x12a
    --- FAIL: TestCallingMockWithExpectationsOfNumberOfCalls/Once (5.01s)
        leaktest.go:126: leaktest: timed out checking goroutines
        leaktest.go:144: leaktest: leaked goroutine: goroutine 174 [chan receive]:
            github.com/buildkite/bintest.NewMock.func1(0xc0003ea1b0)
            	/home/pda/bk/bintest/mock.go:69 +0x72
            created by github.com/buildkite/bintest.NewMock
            	/home/pda/bk/bintest/mock.go:68 +0x12a
    --- FAIL: TestCallingMockWithExpectationsOfNumberOfCalls/Twice (5.05s)
        leaktest.go:126: leaktest: timed out checking goroutines
        leaktest.go:144: leaktest: leaked goroutine: goroutine 258 [chan receive]:
            github.com/buildkite/bintest.NewMock.func1(0xc0000fe120)
            	/home/pda/bk/bintest/mock.go:69 +0x72
            created by github.com/buildkite/bintest.NewMock
            	/home/pda/bk/bintest/mock.go:68 +0x12a
    --- FAIL: TestCallingMockWithExpectationsOfNumberOfCalls/Infinite (5.00s)
        leaktest.go:126: leaktest: timed out checking goroutines
        leaktest.go:144: leaktest: leaked goroutine: goroutine 286 [chan receive]:
            github.com/buildkite/bintest.NewMock.func1(0xc0000fe1b0)
            	/home/pda/bk/bintest/mock.go:69 +0x72
            created by github.com/buildkite/bintest.NewMock
            	/home/pda/bk/bintest/mock.go:68 +0x12a
    --- FAIL: TestCallingMockWithExpectationsOfNumberOfCalls/MinInfinite (5.04s)
        leaktest.go:126: leaktest: timed out checking goroutines
        leaktest.go:144: leaktest: leaked goroutine: goroutine 343 [chan receive]:
            github.com/buildkite/bintest.NewMock.func1(0xc0003ea2d0)
            	/home/pda/bk/bintest/mock.go:69 +0x72
            created by github.com/buildkite/bintest.NewMock
            	/home/pda/bk/bintest/mock.go:68 +0x12a
--- FAIL: TestMockWithCallFunc (5.03s)
    leaktest.go:126: leaktest: timed out checking goroutines
    leaktest.go:144: leaktest: leaked goroutine: goroutine 440 [chan receive]:
        github.com/buildkite/bintest.NewMock.func1(0xc0000fe240)
        	/home/pda/bk/bintest/mock.go:69 +0x72
        created by github.com/buildkite/bintest.NewMock
        	/home/pda/bk/bintest/mock.go:68 +0x12a
--- FAIL: TestMockRequiresExpectations (5.02s)
    leaktest.go:126: leaktest: timed out checking goroutines
    leaktest.go:144: leaktest: leaked goroutine: goroutine 445 [chan receive]:
        github.com/buildkite/bintest.NewMock.func1(0xc0000fe2d0)
        	/home/pda/bk/bintest/mock.go:69 +0x72
        created by github.com/buildkite/bintest.NewMock
        	/home/pda/bk/bintest/mock.go:68 +0x12a
--- FAIL: TestMockIgnoringUnexpectedInvocations (5.02s)
    leaktest.go:126: leaktest: timed out checking goroutines
    leaktest.go:144: leaktest: leaked goroutine: goroutine 449 [chan receive]:
        github.com/buildkite/bintest.NewMock.func1(0xc0000fe3f0)
        	/home/pda/bk/bintest/mock.go:69 +0x72
        created by github.com/buildkite/bintest.NewMock
        	/home/pda/bk/bintest/mock.go:68 +0x12a
--- FAIL: TestMockOptionally (5.02s)
    leaktest.go:126: leaktest: timed out checking goroutines
    leaktest.go:144: leaktest: leaked goroutine: goroutine 508 [chan receive]:
        github.com/buildkite/bintest.NewMock.func1(0xc0003ea360)
        	/home/pda/bk/bintest/mock.go:69 +0x72
        created by github.com/buildkite/bintest.NewMock
        	/home/pda/bk/bintest/mock.go:68 +0x12a
--- FAIL: TestMockExpectWithNoArguments (5.03s)
    leaktest.go:126: leaktest: timed out checking goroutines
    leaktest.go:144: leaktest: leaked goroutine: goroutine 637 [chan receive]:
        github.com/buildkite/bintest.NewMock.func1(0xc0003ea480)
        	/home/pda/bk/bintest/mock.go:69 +0x72
        created by github.com/buildkite/bintest.NewMock
        	/home/pda/bk/bintest/mock.go:68 +0x12a
--- FAIL: TestMockExpectWithMatcherFunc (5.01s)
    leaktest.go:126: leaktest: timed out checking goroutines
    leaktest.go:144: leaktest: leaked goroutine: goroutine 649 [chan receive]:
        github.com/buildkite/bintest.NewMock.func1(0xc0001bc120)
        	/home/pda/bk/bintest/mock.go:69 +0x72
        created by github.com/buildkite/bintest.NewMock
        	/home/pda/bk/bintest/mock.go:68 +0x12a
--- FAIL: TestMockExpectWithBefore (5.02s)
    leaktest.go:126: leaktest: timed out checking goroutines
    leaktest.go:144: leaktest: leaked goroutine: goroutine 694 [chan receive]:
        github.com/buildkite/bintest.NewMock.func1(0xc000230090)
        	/home/pda/bk/bintest/mock.go:69 +0x72
        created by github.com/buildkite/bintest.NewMock
        	/home/pda/bk/bintest/mock.go:68 +0x12a
--- FAIL: TestMockParallelCommandsWithPassthrough (5.02s)
    leaktest.go:126: leaktest: timed out checking goroutines
    leaktest.go:144: leaktest: leaked goroutine: goroutine 713 [chan receive]:
        github.com/buildkite/bintest.NewMock.func1(0xc0000fe480)
        	/home/pda/bk/bintest/mock.go:69 +0x72
        created by github.com/buildkite/bintest.NewMock
        	/home/pda/bk/bintest/mock.go:68 +0x12a
    leaktest.go:144: leaktest: leaked goroutine: goroutine 721 [chan receive]:
        github.com/buildkite/bintest.NewMock.func1(0xc000230120)
        	/home/pda/bk/bintest/mock.go:69 +0x72
        created by github.com/buildkite/bintest.NewMock
        	/home/pda/bk/bintest/mock.go:68 +0x12a
--- FAIL: TestCallingMockWithRelativePath (5.04s)
    leaktest.go:126: leaktest: timed out checking goroutines
    leaktest.go:144: leaktest: leaked goroutine: goroutine 732 [chan receive]:
        github.com/buildkite/bintest.NewMock.func1(0xc0000fe510)
        	/home/pda/bk/bintest/mock.go:69 +0x72
        created by github.com/buildkite/bintest.NewMock
        	/home/pda/bk/bintest/mock.go:68 +0x12a
FAIL
FAIL	github.com/buildkite/bintest	95.843s
FAIL</code></pre>
</details>

After:
> ok  	github.com/buildkite/bintest	3.098s