### PR TITLE
comment linting and test refactoring

### DIFF
--- a/args.go
+++ b/args.go
@@ -134,7 +134,7 @@ func MatchPattern(pattern string) Matcher {
 	}
 }
 
-// Prints a slice of strings as quoted arguments
+// FormatStrings formats a slice of strings as quoted comma-separated arguments
 func FormatStrings(a []string) string {
 	var s = make([]string, len(a))
 	for idx := range a {
@@ -143,7 +143,7 @@ func FormatStrings(a []string) string {
 	return strings.Join(s, ", ")
 }
 
-// Prints a slice of interface{} as quoted arguments
+// FormatInterfaces formats a slice of interface{} as quoted comma-separated arguments
 func FormatInterfaces(a []interface{}) string {
 	var s = make([]string, len(a))
 	for idx := range a {

--- a/client_test.go
+++ b/client_test.go
@@ -1,7 +1,6 @@
 package bintest_test
 
 import (
-	"bytes"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -9,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/buildkite/bintest/v3"
+	"github.com/buildkite/bintest/v3/testutil"
 )
 
 func TestClient(t *testing.T) {
@@ -33,8 +33,8 @@ func TestClient(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	stdout := &closingBuffer{}
-	stderr := &closingBuffer{}
+	stdout := &testutil.ClosingBuffer{}
+	stderr := &testutil.ClosingBuffer{}
 
 	c := bintest.Client{
 		Debug:  false,
@@ -48,21 +48,10 @@ func TestClient(t *testing.T) {
 	if exitCode := c.Run(); exitCode != 0 {
 		t.Fatalf("Expected error code of 0, got %d", exitCode)
 	}
-
 	if expected := "Success (stdout)!\n"; stdout.String() != expected {
 		t.Fatalf("Expected stdout of %q, got %q", expected, stdout.String())
 	}
-
 	if expected := "Success (stdout)!\n"; stdout.String() != expected {
 		t.Fatalf("Expected stdout of %q, got %q", expected, stdout.String())
 	}
-
-}
-
-type closingBuffer struct {
-	bytes.Buffer
-}
-
-func (cb *closingBuffer) Close() error {
-	return nil
 }

--- a/expectation.go
+++ b/expectation.go
@@ -92,7 +92,7 @@ func (e *Expectation) AtLeastOnce() *Expectation {
 	return e.Min(1).Max(InfiniteTimes)
 }
 
-// AndEndsWith causes the invoker to finish with an exit code of code
+// AndExitWith causes the invoker to finish with an exit code of code
 func (e *Expectation) AndExitWith(code int) *Expectation {
 	e.Lock()
 	defer e.Unlock()
@@ -110,7 +110,7 @@ func (e *Expectation) AndWriteToStdout(s string) *Expectation {
 	return e
 }
 
-// AndWriteToStdout causes the invoker to output s to stderr. This resets any passthrough path set
+// AndWriteToStderr causes the invoker to output s to stderr. This resets any passthrough path set
 func (e *Expectation) AndWriteToStderr(s string) *Expectation {
 	e.Lock()
 	defer e.Unlock()
@@ -207,7 +207,8 @@ type ExpectationResult struct {
 // ExpectationResultSet is a collection of ExpectationResult
 type ExpectationResultSet []ExpectationResult
 
-// ExactMatch returns the first Expectation that matches exactly
+// Match returns the first Expectation that matches exactly,
+// or ErrNoExpectationsMatch if none match.
 func (r ExpectationResultSet) Match() (*Expectation, error) {
 	for _, row := range r {
 		if row.ArgumentsMatchResult.IsMatch && row.CallCountMatch {
@@ -217,7 +218,7 @@ func (r ExpectationResultSet) Match() (*Expectation, error) {
 	return nil, ErrNoExpectationsMatch
 }
 
-// BestMatch returns the ExpectationResult that was the closest match (if not the exact)
+// ClosestMatch returns the ExpectationResult that was the closest match (if not the exact)
 // This is used for suggesting what the user might have meant
 func (r ExpectationResultSet) ClosestMatch() ExpectationResult {
 	var closest ExpectationResult

--- a/expectation_test.go
+++ b/expectation_test.go
@@ -1,9 +1,10 @@
 package bintest
 
 import (
-	"fmt"
 	"reflect"
 	"testing"
+
+	"github.com/buildkite/bintest/v3/testutil"
 )
 
 func TestMatchExpectations(t *testing.T) {
@@ -55,19 +56,6 @@ func TestExplainExpectationMatch(t *testing.T) {
 	}
 }
 
-type testingT struct {
-	Logs   []string
-	Errors []string
-}
-
-func (t *testingT) Logf(format string, args ...interface{}) {
-	t.Logs = append(t.Logs, fmt.Sprintf(format, args...))
-}
-
-func (t *testingT) Errorf(format string, args ...interface{}) {
-	t.Errors = append(t.Errors, fmt.Sprintf(format, args...))
-}
-
 func TestCheckIndividualExpectations(t *testing.T) {
 	var match = []*Expectation{
 		{name: "test", arguments: Arguments{"llamas", "rock"}, totalCalls: 1, minCalls: 1, maxCalls: 1},
@@ -88,7 +76,7 @@ func TestCheckIndividualExpectations(t *testing.T) {
 	}
 
 	for _, exp := range notMatch {
-		if exp.Check(&testingT{}) {
+		if exp.Check(&testutil.TestingT{}) {
 			t.Fatalf("Expected %s to NOT match", exp)
 		}
 	}

--- a/mock.go
+++ b/mock.go
@@ -52,7 +52,7 @@ type Mock struct {
 	passthroughPath string
 }
 
-// Mock returns a new Mock instance, or fails if the bintest fails to compile
+// NewMock builds a new Mock, or an error if the bintest fails to compile
 func NewMock(path string) (*Mock, error) {
 	m := &Mock{}
 

--- a/mock_test.go
+++ b/mock_test.go
@@ -11,21 +11,9 @@ import (
 	"testing"
 
 	"github.com/buildkite/bintest/v3"
+	"github.com/buildkite/bintest/v3/testutil"
 	"github.com/fortytw2/leaktest"
 )
-
-type testingT struct {
-	Logs   []string
-	Errors []string
-}
-
-func (t *testingT) Logf(format string, args ...interface{}) {
-	t.Logs = append(t.Logs, fmt.Sprintf(format, args...))
-}
-
-func (t *testingT) Errorf(format string, args ...interface{}) {
-	t.Errors = append(t.Errors, fmt.Sprintf(format, args...))
-}
 
 func TestCallingMockWithStdErrExpected(t *testing.T) {
 	defer leaktest.Check(t)()
@@ -39,7 +27,7 @@ func TestCallingMockWithStdErrExpected(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	mt := &testingT{}
+	mt := &testutil.TestingT{}
 	if m.Check(mt) == false {
 		t.Errorf("Assertions should have passed")
 	}
@@ -60,7 +48,7 @@ func TestCallingMockWithStdOutExpected(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	mt := &testingT{}
+	mt := &testutil.TestingT{}
 	if m.Check(mt) == false {
 		t.Errorf("Assertions should have passed")
 	}
@@ -79,7 +67,7 @@ func TestCallingMockWithNoExpectationsSet(t *testing.T) {
 		t.Errorf("Expected a failure without any expectations set")
 	}
 
-	mt := &testingT{}
+	mt := &testutil.TestingT{}
 	if m.Check(mt) == false {
 		t.Errorf("Assertions should have passed (there were none)")
 	}
@@ -104,7 +92,7 @@ func TestCallingMockWithExpectationsSet(t *testing.T) {
 		t.Fatalf("Unexpected output %q", out)
 	}
 
-	mt := &testingT{}
+	mt := &testutil.TestingT{}
 	if m.Check(mt) == false {
 		t.Errorf("Assertions should have passed")
 	}
@@ -123,7 +111,7 @@ func TestMockWithPassthroughToLocalCommand(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if m.Check(&testingT{}) == false {
+	if m.Check(&testutil.TestingT{}) == false {
 		t.Errorf("Assertions should have passed")
 	}
 	if expected := "hello world\n"; string(out) != expected {
@@ -198,7 +186,7 @@ func TestMockWithCallFunc(t *testing.T) {
 	if string(out) != "hello world\n" {
 		t.Fatalf("Unexpected output %q", out)
 	}
-	if m.Check(&testingT{}) == false {
+	if m.Check(&testutil.TestingT{}) == false {
 		t.Errorf("Assertions should have passed")
 	}
 }
@@ -212,7 +200,7 @@ func TestMockRequiresExpectations(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if m.Check(&testingT{}) == false {
+	if m.Check(&testutil.TestingT{}) == false {
 		t.Errorf("Assertions should have failed")
 	}
 }
@@ -234,7 +222,7 @@ func TestMockIgnoringUnexpectedInvocations(t *testing.T) {
 	_ = exec.Command(m.Path, "fourth", "call").Run()
 	_ = exec.Command(m.Path, "fifth", "call").Run()
 
-	if m.Check(&testingT{}) == false {
+	if m.Check(&testutil.TestingT{}) == false {
 		t.Errorf("Assertions should have passed")
 	}
 }
@@ -392,7 +380,7 @@ func TestCallingMockWithRelativePath(t *testing.T) {
 		t.Errorf("Expected no failures: %v", err)
 	}
 
-	mt := &testingT{}
+	mt := &testutil.TestingT{}
 
 	if m.Check(mt) == false {
 		t.Errorf("Assertions should have passed")

--- a/mock_test.go
+++ b/mock_test.go
@@ -27,15 +27,8 @@ func (t *testingT) Errorf(format string, args ...interface{}) {
 	t.Errors = append(t.Errors, fmt.Sprintf(format, args...))
 }
 
-func tearDown(t *testing.T) func() {
-	leakTest := leaktest.Check(t)
-	return func() {
-		leakTest()
-	}
-}
-
 func TestCallingMockWithStdErrExpected(t *testing.T) {
-	defer tearDown(t)()
+	defer leaktest.Check(t)()
 	m, close := mustMock(t, "test")
 	defer close()
 
@@ -56,7 +49,7 @@ func TestCallingMockWithStdErrExpected(t *testing.T) {
 }
 
 func TestCallingMockWithStdOutExpected(t *testing.T) {
-	defer tearDown(t)()
+	defer leaktest.Check(t)()
 	m, close := mustMock(t, "test")
 	defer close()
 
@@ -77,7 +70,7 @@ func TestCallingMockWithStdOutExpected(t *testing.T) {
 }
 
 func TestCallingMockWithNoExpectationsSet(t *testing.T) {
-	defer tearDown(t)()
+	defer leaktest.Check(t)()
 	m, close := mustMock(t, "test")
 	defer close()
 
@@ -93,7 +86,7 @@ func TestCallingMockWithNoExpectationsSet(t *testing.T) {
 }
 
 func TestCallingMockWithExpectationsSet(t *testing.T) {
-	defer tearDown(t)()
+	defer leaktest.Check(t)()
 	m, close := mustMock(t, "test")
 	defer close()
 
@@ -118,7 +111,7 @@ func TestCallingMockWithExpectationsSet(t *testing.T) {
 }
 
 func TestMockWithPassthroughToLocalCommand(t *testing.T) {
-	defer tearDown(t)()
+	defer leaktest.Check(t)()
 	m, close := mustMock(t, "echo")
 	defer close()
 
@@ -153,7 +146,7 @@ func TestCallingMockWithExpectationsOfNumberOfCalls(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.label, func(t *testing.T) {
-			defer tearDown(t)()
+			defer leaktest.Check(t)()
 
 			m, err := bintest.NewMock("test")
 			if err != nil {
@@ -184,7 +177,7 @@ func TestCallingMockWithExpectationsOfNumberOfCalls(t *testing.T) {
 }
 
 func TestMockWithCallFunc(t *testing.T) {
-	defer tearDown(t)()
+	defer leaktest.Check(t)()
 	m, close := mustMock(t, "echo")
 	defer close()
 
@@ -211,7 +204,7 @@ func TestMockWithCallFunc(t *testing.T) {
 }
 
 func TestMockRequiresExpectations(t *testing.T) {
-	defer tearDown(t)()
+	defer leaktest.Check(t)()
 	m, close := mustMock(t, "llamas")
 	defer close()
 
@@ -225,7 +218,7 @@ func TestMockRequiresExpectations(t *testing.T) {
 }
 
 func TestMockIgnoringUnexpectedInvocations(t *testing.T) {
-	defer tearDown(t)()
+	defer leaktest.Check(t)()
 	m, close := mustMock(t, "llamas")
 	defer close()
 
@@ -247,7 +240,7 @@ func TestMockIgnoringUnexpectedInvocations(t *testing.T) {
 }
 
 func TestMockOptionally(t *testing.T) {
-	defer tearDown(t)()
+	defer leaktest.Check(t)()
 	m, close := mustMock(t, "llamas")
 	defer close()
 
@@ -280,7 +273,7 @@ func TestMockMultipleExpects(t *testing.T) {
 }
 
 func TestMockExpectWithNoArguments(t *testing.T) {
-	defer tearDown(t)()
+	defer leaktest.Check(t)()
 	m, close := mustMock(t, "llamas")
 	defer close()
 
@@ -295,7 +288,7 @@ func TestMockExpectWithNoArguments(t *testing.T) {
 }
 
 func TestMockExpectWithMatcherFunc(t *testing.T) {
-	defer tearDown(t)()
+	defer leaktest.Check(t)()
 	m, close := mustMock(t, "llamas")
 	defer close()
 
@@ -316,7 +309,7 @@ func TestMockExpectWithMatcherFunc(t *testing.T) {
 }
 
 func TestMockExpectWithBefore(t *testing.T) {
-	defer tearDown(t)()
+	defer leaktest.Check(t)()
 	m, close := mustMock(t, "true")
 	defer close()
 
@@ -344,7 +337,7 @@ func TestMockExpectWithBefore(t *testing.T) {
 }
 
 func TestMockParallelCommandsWithPassthrough(t *testing.T) {
-	defer tearDown(t)()
+	defer leaktest.Check(t)()
 
 	var wg sync.WaitGroup
 
@@ -385,7 +378,7 @@ func TestMockParallelCommandsWithPassthrough(t *testing.T) {
 }
 
 func TestCallingMockWithRelativePath(t *testing.T) {
-	defer tearDown(t)()
+	defer leaktest.Check(t)()
 	m, close := mustMock(t, "testmock")
 	defer close()
 

--- a/proxy.go
+++ b/proxy.go
@@ -38,8 +38,8 @@ type Proxy struct {
 	tempDir string
 }
 
-// Compile generates a mock binary at the provided path. If just a filename is provided a temp
-// directory is created.
+// CompileProxy generates a mock binary at the provided path.
+// If just a filename is provided a temp directory is created.
 func CompileProxy(path string) (*Proxy, error) {
 	var tempDir string
 
@@ -313,7 +313,7 @@ func (c *Call) passthrough(ctx context.Context, path string, args ...string) {
 	c.Exit(0)
 }
 
-// Returns true if the call is done, doesn't block and is thread-safe
+// IsDone is a non-blocking thread-safe checks whether the call is done.
 func (c *Call) IsDone() bool {
 	return atomic.LoadUint32(&c.done) == 1
 }

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -20,15 +20,8 @@ import (
 	"github.com/fortytw2/leaktest"
 )
 
-func proxyTearDown(t *testing.T) func() {
-	leakTest := leaktest.Check(t)
-	return func() {
-		leakTest()
-	}
-}
-
 func TestProxyWithStdin(t *testing.T) {
-	defer proxyTearDown(t)()
+	defer leaktest.Check(t)()
 
 	proxy, err := bintest.CompileProxy("test")
 	if err != nil {
@@ -71,7 +64,7 @@ func TestProxyWithStdin(t *testing.T) {
 }
 
 func TestProxyWithStdout(t *testing.T) {
-	defer proxyTearDown(t)()
+	defer leaktest.Check(t)()
 
 	proxy, err := bintest.CompileProxy("test")
 	if err != nil {
@@ -107,7 +100,7 @@ func TestProxyWithStdout(t *testing.T) {
 }
 
 func TestProxyWithStderr(t *testing.T) {
-	defer proxyTearDown(t)()
+	defer leaktest.Check(t)()
 
 	proxy, err := bintest.CompileProxy("test")
 	if err != nil {
@@ -142,7 +135,7 @@ func TestProxyWithStderr(t *testing.T) {
 }
 
 func TestProxyWithStdoutAndStderr(t *testing.T) {
-	defer proxyTearDown(t)()
+	defer leaktest.Check(t)()
 
 	proxy, err := bintest.CompileProxy("test")
 	if err != nil {
@@ -189,7 +182,7 @@ func TestProxyWithStdoutAndStderr(t *testing.T) {
 }
 
 func TestProxyWithNoOutput(t *testing.T) {
-	defer proxyTearDown(t)()
+	defer leaktest.Check(t)()
 
 	proxy, err := bintest.CompileProxy("test")
 	if err != nil {
@@ -211,7 +204,7 @@ func TestProxyWithNoOutput(t *testing.T) {
 }
 
 func TestProxyWithLotsOfOutput(t *testing.T) {
-	defer proxyTearDown(t)()
+	defer leaktest.Check(t)()
 
 	var expected string
 	for i := 0; i < 10; i++ {
@@ -257,7 +250,7 @@ func TestProxyWithLotsOfOutput(t *testing.T) {
 }
 
 func TestProxyWithNonZeroExitCode(t *testing.T) {
-	defer proxyTearDown(t)()
+	defer leaktest.Check(t)()
 
 	proxy, err := bintest.CompileProxy("test")
 	if err != nil {
@@ -295,7 +288,7 @@ func TestProxyWithNonZeroExitCode(t *testing.T) {
 }
 
 func TestProxyCloseRemovesFile(t *testing.T) {
-	defer proxyTearDown(t)()
+	defer leaktest.Check(t)()
 
 	proxy, err := bintest.CompileProxy("test")
 	if err != nil {
@@ -333,7 +326,7 @@ func TestProxyCloseRemovesFile(t *testing.T) {
 }
 
 func TestProxyGetsWorkingDirectoryFromClient(t *testing.T) {
-	defer proxyTearDown(t)()
+	defer leaktest.Check(t)()
 
 	tempDir, err := ioutil.TempDir("", "proxy-wd-test")
 	if err != nil {
@@ -374,7 +367,7 @@ func TestProxyGetsWorkingDirectoryFromClient(t *testing.T) {
 }
 
 func TestProxyWithPassthroughWithNoStdin(t *testing.T) {
-	defer proxyTearDown(t)()
+	defer leaktest.Check(t)()
 
 	echoCmd := `/bin/echo`
 	if runtime.GOOS == `windows` {
@@ -421,7 +414,7 @@ func TestProxyWithPassthroughWithNoStdin(t *testing.T) {
 }
 
 func TestProxyWithPassthroughWithStdin(t *testing.T) {
-	defer proxyTearDown(t)()
+	defer leaktest.Check(t)()
 
 	catCmd := `/bin/cat`
 	if runtime.GOOS == `windows` {
@@ -467,7 +460,7 @@ func TestProxyWithPassthroughWithStdin(t *testing.T) {
 }
 
 func TestProxyWithPassthroughWithFailingCommand(t *testing.T) {
-	defer proxyTearDown(t)()
+	defer leaktest.Check(t)()
 
 	falseCmd := `/usr/bin/false`
 	if runtime.GOOS == `windows` {
@@ -502,7 +495,7 @@ func TestProxyWithPassthroughWithFailingCommand(t *testing.T) {
 }
 
 func TestProxyWithPassthroughWithTimeout(t *testing.T) {
-	defer proxyTearDown(t)()
+	defer leaktest.Check(t)()
 
 	if runtime.GOOS == `windows` {
 		t.Skipf("Not implemented for windows")
@@ -536,7 +529,7 @@ func TestProxyWithPassthroughWithTimeout(t *testing.T) {
 }
 
 func TestProxyCallingInParallel(t *testing.T) {
-	defer proxyTearDown(t)()
+	defer leaktest.Check(t)()
 
 	var wg sync.WaitGroup
 

--- a/server.go
+++ b/server.go
@@ -52,7 +52,7 @@ func StartServer() (*Server, error) {
 	return serverInstance, nil
 }
 
-// Stop the shared http server instance
+// StopServer stops the shared http server instance
 func StopServer() error {
 	serverLock.Lock()
 	defer serverLock.Unlock()

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -1,0 +1,48 @@
+package testutil
+
+import (
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestingT is a fake partial testing.T, which implements the
+// bintest.TestingT interface for capturing log & error messages.
+type TestingT struct {
+	Logs   []string
+	Errors []string
+}
+
+// Logf stores a log message
+func (t *TestingT) Logf(format string, args ...interface{}) {
+	t.Logs = append(t.Logs, fmt.Sprintf(format, args...))
+}
+
+// Errorf stores an error message
+func (t *TestingT) Errorf(format string, args ...interface{}) {
+	t.Errors = append(t.Errors, fmt.Sprintf(format, args...))
+}
+
+// WriteBatchFile writes the given lines as a windows batch file of the given
+// name in a new temporary directory.
+func WriteBatchFile(t *testing.T, name string, lines []string) string {
+	tmpDir, err := ioutil.TempDir("", "batch-files-of-horror")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	batchfile := filepath.Join(tmpDir, name)
+	err = ioutil.WriteFile(batchfile, []byte(strings.Join(lines, "\r\n")), 0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return batchfile
+}
+
+// NormalizeNewlines converts Windows newlines to Unix style
+func NormalizeNewlines(s string) string {
+	return strings.ReplaceAll(s, "\r\n", "\n")
+}

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -1,6 +1,7 @@
 package testutil
 
 import (
+	"bytes"
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
@@ -45,4 +46,16 @@ func WriteBatchFile(t *testing.T, name string, lines []string) string {
 // NormalizeNewlines converts Windows newlines to Unix style
 func NormalizeNewlines(s string) string {
 	return strings.ReplaceAll(s, "\r\n", "\n")
+}
+
+// ClosingBuffer adds Close() to bytes.Buffer, such that it implements the
+// io.WriteCloser interface in addition to e.g. fmt.Stringer interfaces that
+// bytes.Buffer already implements.
+type ClosingBuffer struct {
+	bytes.Buffer
+}
+
+// Close does nothing
+func (bc *ClosingBuffer) Close() error {
+	return nil
 }


### PR DESCRIPTION
This is a superficial PR cherry-picking some refactoring and linting done working on another upcoming PR. It only touches comments and test code. The main change is extracting various test helpers into a new `testutil` package to improve the signal-to-noise of the tests themselves.