### PR TITLE
Expectation.WithStdin(matcher) to assert expected stdin

### DIFF
--- a/expectation.go
+++ b/expectation.go
@@ -201,7 +201,8 @@ func (e *Expectation) checkStdin(t TestingT) bool {
 	switch expected := e.stdin.(type) {
 	case string:
 		if expected != actual {
-			if len(actual) <= 64 {
+			// if the stdin was very long, just report the size, not the content
+			if len(actual) <= 1024 {
 				t.Logf("Expected stdin %q, got %q", expected, actual)
 			} else {
 				t.Logf("Expected %d bytes stdin, got %d bytes", len(expected), len(e.readStdin))

--- a/mock.go
+++ b/mock.go
@@ -142,7 +142,8 @@ func (m *Mock) invoke(call *Call) {
 		// read all of stdin
 		buf, err := ioutil.ReadAll(call.Stdin)
 		if err != nil {
-			panic("error reading stdin")
+			fmt.Fprintf(call.Stderr, "\033[31m🚨 Error reading stdin: %v\033[0m\n", err)
+			call.Exit(1)
 		}
 		// copy to Expectation
 		expected.readStdin = make([]byte, len(buf))

--- a/mock.go
+++ b/mock.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -136,6 +137,19 @@ func (m *Mock) invoke(call *Call) {
 	debugf("Found expectation: %s", expected)
 
 	invocation.Expectation = expected
+
+	if expected.stdin != nil {
+		// read all of stdin
+		buf, err := ioutil.ReadAll(call.Stdin)
+		if err != nil {
+			panic("error reading stdin")
+		}
+		// copy to Expectation
+		expected.readStdin = make([]byte, len(buf))
+		copy(expected.readStdin, buf)
+		// restore original stdin
+		call.Stdin = ioutil.NopCloser(bytes.NewReader(buf))
+	}
 
 	if m.passthroughPath != "" {
 		call.PassthroughWithTimeout(m.passthroughPath, time.Second*10)

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -26,6 +26,16 @@ func (t *TestingT) Errorf(format string, args ...interface{}) {
 	t.Errors = append(t.Errors, fmt.Sprintf(format, args...))
 }
 
+// Copy dumps the Logs and Errors into another test context
+func (t *TestingT) Copy(dst *testing.T) {
+	for _, s := range t.Logs {
+		dst.Log(s)
+	}
+	for _, s := range t.Errors {
+		dst.Error(s)
+	}
+}
+
 // WriteBatchFile writes the given lines as a windows batch file of the given
 // name in a new temporary directory.
 func WriteBatchFile(t *testing.T, name string, lines []string) string {


### PR DESCRIPTION
Add `bintest.Expectation.WithStdin(matcher)` so that expectations can be set against the stdin of the command.

```go
agent, _ := bintest.NewMock("buildkite-agent")

// existing behavior: expect arguments
agent.Expect("meta-data", "set", "hello", bintest.MatchPattern("^world"))

// new behavior: expect stdin too
agent.Expect("meta-data", "set", "hello").WithStdin(bintest.MatchPattern("^world"))

// verbatim strings work too
agent.Expect("meta-data", "set", "hello").WithStdin("world")
```

This is required for https://github.com/buildkite/agent/pull/1302