### PR TITLE
Prevent data race between channel close and send

### DIFF
--- a/server.go
+++ b/server.go
@@ -229,8 +229,7 @@ func (s *Server) handleNewCall(w http.ResponseWriter, r *http.Request) {
 
 	debugf("[server] Registered call handler for pid %d", call.PID)
 
-	// dispatch to whatever handles the call
-	proxy.Ch <- call
+	proxy.dispatch(call)
 }
 
 type callHandler struct {


### PR DESCRIPTION
The agent tests encountered a data race here. Concurrently closing and sending on the same channel is racy.

While I'm here, slightly simplify the rest of Proxy.Close.