### PR TITLE
Fix write-exec-ETXTBSY race

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -2,7 +2,7 @@ package bintest_test
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -23,7 +23,7 @@ func TestClient(t *testing.T) {
 		case `/calls/1234567/exitcode`:
 			fmt.Fprintln(w, `0`)
 		case `/debug`:
-			out, _ := ioutil.ReadAll(r.Body)
+			out, _ := io.ReadAll(r.Body)
 			_ = r.Body.Close()
 			t.Logf("%s", out)
 		default:

--- a/compiler.go
+++ b/compiler.go
@@ -107,12 +107,12 @@ func compileClient(dest string, vars []string) error {
 	dir := fmt.Sprintf(`_bintest_%x`, sha1.Sum([]byte(clientSrc)))
 	f := filepath.Join(dir, `main.go`)
 
-	if err := os.MkdirAll(dir, 0700); err != nil {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return err
 	}
 	defer os.RemoveAll(dir)
 
-	if err := os.WriteFile(f, []byte(clientSrc), 0500); err != nil {
+	if err := os.WriteFile(f, []byte(clientSrc), 0o500); err != nil {
 		return err
 	}
 

--- a/compiler.go
+++ b/compiler.go
@@ -151,11 +151,8 @@ func (c *compileCache) IsCached(vars []string) bool {
 		panic(err)
 	}
 
-	if _, err := os.Stat(path); err == nil {
-		return true
-	}
-
-	return false
+	_, err = os.Stat(path)
+	return err == nil
 }
 
 func (c *compileCache) Copy(dest string, vars []string) error {

--- a/compiler.go
+++ b/compiler.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -111,7 +110,7 @@ func compileClient(dest string, vars []string) error {
 	if _, err := os.Lstat(dir); os.IsNotExist(err) {
 		_ = os.Mkdir(filepath.Join(wd, dir), 0700)
 
-		if err = ioutil.WriteFile(f, []byte(clientSrc), 0500); err != nil {
+		if err = os.WriteFile(f, []byte(clientSrc), 0500); err != nil {
 			_ = os.RemoveAll(dir)
 			return err
 		}
@@ -138,7 +137,7 @@ func newCompileCache() (*compileCache, error) {
 	cc := &compileCache{}
 
 	var err error
-	cc.Dir, err = ioutil.TempDir("", "binproxy")
+	cc.Dir, err = os.MkdirTemp("", "binproxy")
 	if err != nil {
 		return nil, fmt.Errorf("Error creating temp dir: %v", err)
 	}
@@ -212,7 +211,7 @@ func copyFile(dst, src string, perm os.FileMode) (err error) {
 		err = in.Close()
 	}()
 
-	tmp, err := ioutil.TempFile(filepath.Dir(dst), "")
+	tmp, err := os.CreateTemp(filepath.Dir(dst), "")
 	if err != nil {
 		return err
 	}

--- a/compiler.go
+++ b/compiler.go
@@ -97,27 +97,21 @@ func compileClient(dest string, vars []string) error {
 		return compileCacheInstance.Copy(dest, vars)
 	}
 
-	wd, err := os.Getwd()
-	if err != nil {
-		return err
-	}
-
 	// we create a temp subdir relative to current dir so that
 	// we can make use of gopath / vendor dirs
 	dir := fmt.Sprintf(`_bintest_%x`, sha1.Sum([]byte(clientSrc)))
 	f := filepath.Join(dir, `main.go`)
 
-	if _, err := os.Lstat(dir); os.IsNotExist(err) {
-		_ = os.Mkdir(filepath.Join(wd, dir), 0700)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return err
+	}
+	defer os.RemoveAll(dir)
 
-		if err = os.WriteFile(f, []byte(clientSrc), 0500); err != nil {
-			_ = os.RemoveAll(dir)
-			return err
-		}
+	if err := os.WriteFile(f, []byte(clientSrc), 0500); err != nil {
+		return err
 	}
 
 	if err := compile(dest, f, vars); err != nil {
-		_ = os.RemoveAll(dir)
 		return err
 	}
 

--- a/compiler_test.go
+++ b/compiler_test.go
@@ -5,6 +5,8 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"strconv"
+	"testing"
 
 	"github.com/buildkite/bintest/v3"
 )
@@ -42,4 +44,40 @@ func ExampleCompileProxy() {
 	}
 
 	// Output: Llama party! 🎉
+}
+
+func TestCompileProxy_GoBug22315(t *testing.T) {
+	// On Linux (and possibly other Unices), there exists a race condition that
+	// manifests when you write and then execute a binary file in a multi-
+	// -threaded program. See https://github.com/golang/go/issues/22315.
+	// This is debatably a bug in either Linux or Go, but the Go bug has a
+	// lengthy discussion.
+	//
+	// bintest used to operate by copying the compiled binaries around. Copying
+	// necessarily requires opening the destination file for writing. Then,
+	// bintest provides the path of the freshly-copied binary to the test that
+	// is using bintest, which usually immediately executes that binary.
+	// Throw in a bit of t.Parallel and you have a recipe for test flakes.
+
+	t.Parallel()
+	for i := 0; i < 1000; i++ {
+		name := fmt.Sprintf("%s-%d", t.Name(), i)
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			t.Parallel()
+
+			m, err := bintest.NewMock(name)
+			if err != nil {
+				t.Fatalf("bintest.NewMock(%q) error = %v", name, err)
+			}
+			defer m.CheckAndClose(t)
+
+			m.Expect().AndExitWith(0)
+
+			// If file copying is used in process, and the race conditions are
+			// unfavourable, Run will fail with "text file busy" (ETXTBSY).
+			if err := exec.Command(m.Path).Run(); err != nil {
+				t.Errorf("exec.Command(%q).Run() = %v", m.Path, err)
+			}
+		})
+	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,10 @@
 module github.com/buildkite/bintest/v3
 
-go 1.12
+go 1.20
 
 require (
 	github.com/fortytw2/leaktest v1.3.0
-	github.com/petermattis/goid v0.0.0-20180202154549-b0b1615b78e5 // indirect
 	github.com/sasha-s/go-deadlock v0.0.0-20180226215254-237a9547c8a5
 )
+
+require github.com/petermattis/goid v0.0.0-20180202154549-b0b1615b78e5 // indirect

--- a/mock.go
+++ b/mock.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -140,7 +139,7 @@ func (m *Mock) invoke(call *Call) {
 
 	if expected.stdin != nil {
 		// read all of stdin
-		buf, err := ioutil.ReadAll(call.Stdin)
+		buf, err := io.ReadAll(call.Stdin)
 		if err != nil {
 			fmt.Fprintf(call.Stderr, "\033[31m🚨 Error reading stdin: %v\033[0m\n", err)
 			call.Exit(1)
@@ -149,7 +148,7 @@ func (m *Mock) invoke(call *Call) {
 		expected.readStdin = make([]byte, len(buf))
 		copy(expected.readStdin, buf)
 		// restore original stdin
-		call.Stdin = ioutil.NopCloser(bytes.NewReader(buf))
+		call.Stdin = io.NopCloser(bytes.NewReader(buf))
 	}
 
 	if m.passthroughPath != "" {

--- a/mock_test.go
+++ b/mock_test.go
@@ -2,7 +2,6 @@ package bintest_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -422,7 +421,7 @@ func TestMockParallelCommandsWithPassthrough(t *testing.T) {
 	var wg sync.WaitGroup
 
 	for i := 1; i < 3; i++ {
-		tmpDir, err := ioutil.TempDir("", "parallel-mocks")
+		tmpDir, err := os.MkdirTemp("", "parallel-mocks")
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/proxy.go
+++ b/proxy.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -49,7 +48,7 @@ func CompileProxy(path string) (*Proxy, error) {
 
 	if !filepath.IsAbs(path) {
 		var err error
-		tempDir, err = ioutil.TempDir("", "binproxy")
+		tempDir, err = os.MkdirTemp("", "binproxy")
 		if err != nil {
 			return nil, fmt.Errorf("Error creating temp dir: %v", err)
 		}
@@ -105,7 +104,7 @@ func LinkTestBinaryAsProxy(path string) (*Proxy, error) {
 
 	if !filepath.IsAbs(path) {
 		var err error
-		tempDir, err = ioutil.TempDir("", "binproxy")
+		tempDir, err = os.MkdirTemp("", "binproxy")
 		if err != nil {
 			return nil, fmt.Errorf("Error creating temp dir: %v", err)
 		}

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"reflect"
@@ -328,7 +327,7 @@ func TestProxyCloseRemovesFile(t *testing.T) {
 func TestProxyGetsWorkingDirectoryFromClient(t *testing.T) {
 	defer leaktest.Check(t)()
 
-	tempDir, err := ioutil.TempDir("", "proxy-wd-test")
+	tempDir, err := os.MkdirTemp("", "proxy-wd-test")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/server.go
+++ b/server.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"path"
@@ -135,7 +134,7 @@ var (
 
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if r.URL.Path == "/debug" {
-		body, _ := ioutil.ReadAll(r.Body)
+		body, _ := io.ReadAll(r.Body)
 		_ = r.Body.Close()
 		debugf("%s", body)
 		return

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -3,7 +3,7 @@ package testutil
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -39,13 +39,13 @@ func (t *TestingT) Copy(dst *testing.T) {
 // WriteBatchFile writes the given lines as a windows batch file of the given
 // name in a new temporary directory.
 func WriteBatchFile(t *testing.T, name string, lines []string) string {
-	tmpDir, err := ioutil.TempDir("", "batch-files-of-horror")
+	tmpDir, err := os.MkdirTemp("", "batch-files-of-horror")
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	batchfile := filepath.Join(tmpDir, name)
-	err = ioutil.WriteFile(batchfile, []byte(strings.Join(lines, "\r\n")), 0600)
+	err = os.WriteFile(batchfile, []byte(strings.Join(lines, "\r\n")), 0600)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -45,7 +45,7 @@ func WriteBatchFile(t *testing.T, name string, lines []string) string {
 	}
 
 	batchfile := filepath.Join(tmpDir, name)
-	err = os.WriteFile(batchfile, []byte(strings.Join(lines, "\r\n")), 0600)
+	err = os.WriteFile(batchfile, []byte(strings.Join(lines, "\r\n")), 0o600)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
I'm reluctant to fix bintest, but the number of tests we have in the agent using bintest is still high, and the flakes are annoying.

There is a bug in Go, or a design flaw in Linux and some other/older Unices (which one depends on your point of view). When writing and then executing binaries in a multithreaded program, there is a race condition that causes the exec to fail with `ETXTBSY`. See https://github.com/golang/go/issues/22315.

This shows up as a flake in some of the agent tests, as exit code -1 on running the bintest client binary (the underlying error is `text file busy`, which is normally uploaded in the job log, but is inaccessible to the tests).

A solution is to build the client binary directly into the cache, and replace `copyFile` with symlinking. This works because [symlink(2)](https://man7.org/linux/man-pages/man2/symlink.2.html) is a single syscall, and at no point requires the process to have a file descriptor open with write on the symlink (which would temporarily leak into forked processes). This has the added benefit of being nicer to the filesystem (symlinks are small compared with Go binaries).

Aside: why doesn't the initial binary compile have this problem? Because the exec of `go build` is a subprocess, its file descriptors don't sneak back into the parent process. (So another solution to the race is to do file copying in a subprocess).

The agent tests pass*, which I verified in a Linux container and a `go.work` configuration (`cd ..` into a common superdirectory, `go work init`, `go work use (path to agent repo)`, `go work use (path to bintest repo)`).

*this was a slight exaggeration when I wrote it, but not now. (Had to install Ruby, copy .buildkite/build/ssh.conf to ~/.ssh/config, and fix two more edge cases.)