### PR TITLE
Remove go-deadlock, update Go to 1.22

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,5 +2,5 @@ steps:
   - command: go test -v ./...
     plugins:
       docker#v1.1.1:
-        image: "golang:1.9.3"
+        image: "golang:1.22"
         workdir: /go/src/github.com/buildkite/bintest

--- a/compiler.go
+++ b/compiler.go
@@ -10,9 +10,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
-
-	deadlock "github.com/sasha-s/go-deadlock"
 )
 
 const (
@@ -43,7 +42,7 @@ func main() {
 
 var (
 	compileCacheInstance *compileCache
-	compileLock          deadlock.Mutex
+	compileLock          sync.Mutex
 )
 
 func compile(dest string, src string, vars []string) error {

--- a/expectation.go
+++ b/expectation.go
@@ -6,13 +6,12 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-
-	"github.com/sasha-s/go-deadlock"
+	"sync"
 )
 
 // Expectation is used for setting expectations
 type Expectation struct {
-	deadlock.RWMutex
+	sync.RWMutex
 
 	// Name of the binary that the expectation is against
 	name string

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,5 @@
 module github.com/buildkite/bintest/v3
 
-go 1.20
+go 1.22
 
-require (
-	github.com/fortytw2/leaktest v1.3.0
-	github.com/sasha-s/go-deadlock v0.0.0-20180226215254-237a9547c8a5
-)
-
-require github.com/petermattis/goid v0.0.0-20180202154549-b0b1615b78e5 // indirect
+require github.com/fortytw2/leaktest v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,2 @@
 github.com/fortytw2/leaktest v1.3.0 h1:u8491cBMTQ8ft8aeV+adlcytMZylmA5nnwwkRZjI8vw=
 github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
-github.com/petermattis/goid v0.0.0-20180202154549-b0b1615b78e5 h1:q2e307iGHPdTGp0hoxKjt1H5pDo6utceo3dQVK3I5XQ=
-github.com/petermattis/goid v0.0.0-20180202154549-b0b1615b78e5/go.mod h1:jvVRKCrJTQWu0XVbaOlby/2lO20uSCHEMzzplHXte1o=
-github.com/sasha-s/go-deadlock v0.0.0-20180226215254-237a9547c8a5 h1:T7hUw7pBSINuHQyWwMdfIWZZH5M3ju4yXIbuV/Upp+4=
-github.com/sasha-s/go-deadlock v0.0.0-20180226215254-237a9547c8a5/go.mod h1:StQn567HiB1fF2yJ44N9au7wOhrPS3iZqiDbRupzT10=

--- a/mock.go
+++ b/mock.go
@@ -8,9 +8,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
-
-	"github.com/sasha-s/go-deadlock"
 )
 
 const (
@@ -25,7 +24,7 @@ type TestingT interface {
 
 // Mock provides a wrapper around a Proxy for testing
 type Mock struct {
-	deadlock.Mutex
+	sync.Mutex
 
 	// Name of the binary
 	Name string

--- a/server.go
+++ b/server.go
@@ -11,8 +11,6 @@ import (
 	"strconv"
 	"sync"
 	"time"
-
-	"github.com/sasha-s/go-deadlock"
 )
 
 // A single instance of the server is run for each golang process. The server has sessions which then
@@ -20,7 +18,7 @@ import (
 
 var (
 	serverInstance *Server
-	serverLock     deadlock.Mutex
+	serverLock     sync.Mutex
 )
 
 // StartServer starts an instance of a proxy server


### PR DESCRIPTION
We could update `go-deadlock` to a version that will work with Go 1.23. 

However, at this point, we've more or less determined any deadlocks that could occur using bintest in existing tests, and we should avoid bintest for any new shapes of test.

So I think we should delete the dependency instead.
